### PR TITLE
Use M3 colours from anvil

### DIFF
--- a/data/theme.json
+++ b/data/theme.json
@@ -2,30 +2,30 @@
   "colors": {
     "default": {
       "theme_color": {
-        "primary": "#121212",
-        "body": "#fff",
-        "border": "#eaeaea",
-        "theme_light": "#f6f6f6",
+        "primary": "#1c1b1f",
+        "body": "#fffbfe",
+        "border": "#49454e",
+        "theme_light": "#e7e0ec",
         "theme_dark": ""
       },
       "text_color": {
-        "default": "#444444",
-        "dark": "#040404",
-        "light": "#717171"
+        "default": "#49454e",
+        "dark": "#1c1b1f",
+        "light": "#49454e"
       }
     },
     "darkmode": {
       "theme_color": {
-        "primary": "#fff",
-        "body": "#1c1c1c",
-        "border": "#3E3E3E",
-        "theme_light": "#222222",
+        "primary": "#e6e1e5",
+        "body": "#1c1b1f",
+        "border": "#cac4d0",
+        "theme_light": "#49454f",
         "theme_dark": ""
       },
       "text_color": {
-        "default": "#B4AFB6",
-        "dark": "#fff",
-        "light": "#B4AFB6"
+        "default": "#cac4d0",
+        "dark": "#e6e1e5",
+        "light": "#cac4d0"
       }
     }
   },


### PR DESCRIPTION
Because we're embedding Anvil apps in the site and the colours don't quite match up.

It's much easier to take the M3 colour codes from anvil and use them here than it would be to specify a whole new M3 scheme at anvil, so that's what I've done.