### PR TITLE
Add js to send theme change message to iframes

### DIFF
--- a/themes/hugoplate/layouts/partials/components/theme-switcher.html
+++ b/themes/hugoplate/layouts/partials/components/theme-switcher.html
@@ -55,8 +55,18 @@
             "theme",
             document.documentElement.classList.contains("dark") ? "dark" : "light"
           );
+          let iframes = document.querySelectorAll('iframe');
+          iframes.forEach(iframe => {
+            iframe.contentWindow.postMessage({ theme: localStorage.getItem("theme") }, '*');
+          });
         });
       });
     });
+
+    window.addEventListener("message", function(event) {
+      if (event.data && event.data.requestTheme) {
+        event.source.postMessage({ theme: localStorage.getItem("theme") }, event.origin);
+      }
+    })
   </script>
 {{ end }}


### PR DESCRIPTION
This uses the 'postMessage' api in the browser. 

1. The embedded app within a iframe posts a message to request the current theme and this posts a message in response. That's for when the iframe first loads.
2. Whenever the theme switcher is clicked, if there are any iframes on the page, it sends them a message with the current theme